### PR TITLE
Send a message when a pilot checkbox gets clicked

### DIFF
--- a/Android/ChorusRFLaptimer/app/src/main/java/app/andrey_voroshkov/chorus_laptimer/PilotsRssiListAdapter.java
+++ b/Android/ChorusRFLaptimer/app/src/main/java/app/andrey_voroshkov/chorus_laptimer/PilotsRssiListAdapter.java
@@ -123,6 +123,13 @@ public class PilotsRssiListAdapter extends BaseAdapter {
             }
         });
 
+        viewHolder.isPilotEnabled.setOnClickListener(new CompoundButton.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                AppState.getInstance().sendBtCommand("R" + deviceId + "A" + (((CompoundButton)v).isChecked() ? 1 : 0));
+            }
+        });
+
         Boolean isEnabled = AppState.getInstance().getIsPilotEnabled(position);
         viewHolder.isPilotEnabled.setChecked(isEnabled);
 

--- a/Android/ChorusRFLaptimer/app/src/main/java/app/andrey_voroshkov/chorus_laptimer/Utils.java
+++ b/Android/ChorusRFLaptimer/app/src/main/java/app/andrey_voroshkov/chorus_laptimer/Utils.java
@@ -160,6 +160,10 @@ public class Utils {
                     int apiVersion = Integer.parseInt(chunk.substring(3,7), 16);
                     AppState.getInstance().checkApiVersion(moduleId, apiVersion);
                     break;
+                case 'A':
+                    int isPilotActive = Integer.parseInt(chunk.substring(3,4), 16);
+                    AppState.getInstance().changeDeviceEnabled(moduleId, (isPilotActive != 0));
+                    break;
             }
         } else if (dest == 'R') {
 

--- a/Arduino/chorus_rf_laptimer/chorus_rf_laptimer.ino
+++ b/Arduino/chorus_rf_laptimer/chorus_rf_laptimer.ino
@@ -108,6 +108,7 @@ const uint16_t musicNotes[] = {
 #define CONTROL_SOUND               'S'
 #define CONTROL_THRESHOLD           'T'
 #define CONTROL_EXPERIMENTAL_MODE   'E'
+#define CONTROL_PILOT_ACTIVE        'A'
 // get only:
 #define CONTROL_GET_API_VERSION     '#'
 #define CONTROL_GET_ALL_DATA        'a'
@@ -131,6 +132,7 @@ const uint16_t musicNotes[] = {
 #define RESPONSE_SOUND               'S'
 #define RESPONSE_THRESHOLD           'T'
 #define RESPONSE_EXPERIMENTAL_MODE   'E'
+#define RESPONSE_PILOT_ACTIVE        'A'
 
 #define RESPONSE_API_VERSION         '#'
 #define RESPONSE_RSSI                'r'


### PR DESCRIPTION
I am currently using multiplexing to track more pilots than the number of VRX modules available.

So I'd like to propose to send a message when a pilot gets activated or deactivated so the timer can adjust and reduce the accuracy loss.
This could also be used to save power when there are fewer pilots than modules.