### PR TITLE
Fix crash when enabling bluetooth after starting the app

### DIFF
--- a/Android/ChorusRFLaptimer/app/src/main/java/app/andrey_voroshkov/chorus_laptimer/MainActivity.java
+++ b/Android/ChorusRFLaptimer/app/src/main/java/app/andrey_voroshkov/chorus_laptimer/MainActivity.java
@@ -4,6 +4,7 @@ import android.Manifest;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.PendingIntent;
+import android.bluetooth.BluetoothAdapter;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -49,6 +50,7 @@ public class MainActivity extends AppCompatActivity implements ConnectionListene
     private ViewPager mViewPager;
     private Menu menu;
     private BroadcastReceiver mUsbReceiver;
+    private BroadcastReceiver mBluetoothReceiver;
     private PendingIntent mPermissionIntent;
     BTService bt;
     UDPService udp;
@@ -147,7 +149,7 @@ public class MainActivity extends AppCompatActivity implements ConnectionListene
 
         TabLayout tabLayout = (TabLayout) findViewById(R.id.tabs);
         tabLayout.setupWithViewPager(mViewPager);
-
+        initBroadcastReceiverForBluetooth();
         initBluetooth();
         initUDP();
         initBroadcastReceiverForUsbPermissions();
@@ -341,8 +343,15 @@ public class MainActivity extends AppCompatActivity implements ConnectionListene
         super.onActivityResult(requestCode, resultCode, data);
         if (requestCode == BluetoothState.REQUEST_CONNECT_DEVICE) {
             if (resultCode == Activity.RESULT_OK) {
-                bt.connect(data);
-                useBT();
+                if(bt.isServiceAvailable()) {
+                    bt.connect(data);
+                    useBT();
+                } else {
+                    Toast.makeText(getApplicationContext()
+                            , "Bluetooth busy. Try again in a few seconds."
+                            , Toast.LENGTH_SHORT).show();
+                    bt.runService(); // Try to start the service again, in case it failed somewhere
+                }
             }
         } else if (requestCode == BluetoothState.REQUEST_ENABLE_BT) {
             if (resultCode == Activity.RESULT_OK) {
@@ -364,6 +373,22 @@ public class MainActivity extends AppCompatActivity implements ConnectionListene
                     new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
                     REQUEST_WRITE_STORAGE_CODE);
         }
+    }
+
+    private  void initBroadcastReceiverForBluetooth() {
+        mBluetoothReceiver = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                if (BluetoothAdapter.ACTION_STATE_CHANGED.equals(intent.getAction())) {
+                    if(intent.getIntExtra(BluetoothAdapter.EXTRA_STATE, -1) == BluetoothAdapter.STATE_ON) {
+                        bt.runService();
+                    } else {
+                        bt.stopService();
+                    }
+                }
+            }
+        };
+        registerReceiver(mBluetoothReceiver, new IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED));
     }
 
     private void connectToUsbDevice() {


### PR DESCRIPTION
When enabling bluetooth after starting the app and trying to connect, the app crashes due to `mChatService` being null.
This adds a listener to the bluetooth state and starts the bluetooth service when the user enables bluetooth.

I never did much in Android, so I hope implementing it this way is correct.