### PR TITLE
Fix connection on android 10

### DIFF
--- a/Android/ChorusRFLaptimer/app/src/main/java/app/andrey_voroshkov/chorus_laptimer/MainActivity.java
+++ b/Android/ChorusRFLaptimer/app/src/main/java/app/andrey_voroshkov/chorus_laptimer/MainActivity.java
@@ -12,7 +12,9 @@ import android.content.IntentFilter;
 import android.content.pm.PackageInfo;
 import android.hardware.usb.UsbDevice;
 import android.hardware.usb.UsbManager;
+import android.net.ConnectivityManager;
 import android.net.DhcpInfo;
+import android.net.NetworkInfo;
 import android.net.wifi.WifiInfo;
 import android.net.wifi.WifiManager;
 import android.content.pm.PackageManager;
@@ -262,8 +264,12 @@ public class MainActivity extends AppCompatActivity implements ConnectionListene
         WifiManager wifiMgr = (WifiManager) getApplicationContext().getSystemService(WIFI_SERVICE);
         if (!wifiMgr.isWifiEnabled()) return false;  // Wi-Fi adapter is OFF
 
-        WifiInfo wifiInfo = wifiMgr.getConnectionInfo();
-        return wifiInfo.getNetworkId() != -1; // if true, then connected to an access point
+        ConnectivityManager cm =
+            (ConnectivityManager)getApplicationContext().getSystemService(Context.CONNECTIVITY_SERVICE);
+        // Deprecated in Android 10, but should still be fine
+        NetworkInfo activeNetwork = cm.getActiveNetworkInfo();
+        boolean isConnected = activeNetwork != null && activeNetwork.isConnectedOrConnecting();
+        return isConnected;
     }
 
     private String getGatewayIP() {


### PR DESCRIPTION
wifiInfo.getNetworkId() seems to require the location permission on Android 10.
This fix uses the ConnectivityManager to avoid adding a new permission.

Tested on Android 10 and 9.

Fixes #112 